### PR TITLE
fix: permission issue for softprops/action-gh-release@v1 step

### DIFF
--- a/.github/workflows/bump_version.yaml
+++ b/.github/workflows/bump_version.yaml
@@ -9,6 +9,8 @@ jobs:
   bump-version:
     if: "!startsWith(github.event.head_commit.message, 'bump:')"
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     name: "Bump version and create changelog with commitizen"
     steps:
       - name: Check out


### PR DESCRIPTION
It is not enough to add Write access for "Contents" for the PAT. It is also required to add the permission to the workflow itself.

See: https://github.com/softprops/action-gh-release/issues/400

- You can enable write permissions for all workflows in a repo or organization via the Settings->Actions->General GUI option.
- You can enable write permissions for one workflow via the contents: write permission in the .yaml file.